### PR TITLE
Adding app cleanup to deployment scripts

### DIFF
--- a/generators/guestbinary/templates/deploy/install.ps1
+++ b/generators/guestbinary/templates/deploy/install.ps1
@@ -1,4 +1,21 @@
+function Uninstall() {
+    Write-Host "Uninstalling App as installation failed... Please try installation again."
+    Invoke-Expression "& $PSScriptRoot\uninstall.ps1"
+    Exit
+}
+
 $AppPath = "$PSScriptRoot\<%= appPackage %>"
-Copy-ServiceFabricApplicationPackage -ApplicationPackagePath $AppPath -ApplicationPackagePathInImageStore <%= appPackage %>
+Copy-ServiceFabricApplicationPackage -ApplicationPackagePath $AppPath -ApplicationPackagePathInImageStore <%= appPackage %> -ShowProgress
+if (!$?) {
+    Uninstall
+}
+
 Register-ServiceFabricApplicationType <%= appPackage %>
+if (!$?) {
+    Uninstall
+}
+
 New-ServiceFabricApplication fabric:/<%= appName %> <%= appTypeName %> 1.0.0
+if (!$?) {
+    Uninstall
+}

--- a/generators/guestbinary/templates/deploy/install.sh
+++ b/generators/guestbinary/templates/deploy/install.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
+uninstall () {
+    echo "Uninstalling App as installation failed... Please try installation again."
+    ./uninstall.sh
+    exit
+}
 
+cd `dirname $0`
 sfctl application upload --path <%= appPackage %> --show-progress
+if [ $? -ne 0 ]; then
+  uninstall
+fi
+
 sfctl application provision --application-type-build-path <%= appPackage %>
+if [ $? -ne 0 ]; then
+  uninstall
+fi
+
 sfctl application create --app-name fabric:/<%= appName %> --app-type <%= appTypeName %> --app-version 1.0.0
+if [ $? -ne 0 ]; then
+  uninstall
+fi
+
+cd -


### PR DESCRIPTION
- Add clean-up of application packages when installation fails.
- Guest Executable generator, hence only two files changed, as there are no multiple cases as in Stateful, Stateless, Actor etc. 